### PR TITLE
FOGL-9070: change connection retry timings

### DIFF
--- a/dnp3.cpp
+++ b/dnp3.cpp
@@ -68,11 +68,14 @@ bool DNP3::start()
 	{
 		string remoteLabel = "remote_" + to_string(outstation->linkId);
 
+		// Connection retry timings: staring with 20 seconds, then up to 5 minutes
+		auto retry = ChannelRetry(TimeDuration::Seconds(20), TimeDuration::Minutes(5));
+
 		// Create TCP channel for outstation
 		std::shared_ptr<IChannel> channel =
 			manager->AddTCPClient(m_serviceName + "_" + remoteLabel, // alias in log messages
 				      logLevels, // filter what gets logged
-				      ChannelRetry::Default(), // how connections will be retried
+				      auto, // how connections will be retried
 				      // host names or IP address of remote endpoint
 				      outstation->address, 
 				      // interface adapter on which to attempt the connection (any adapter)

--- a/dnp3.cpp
+++ b/dnp3.cpp
@@ -75,7 +75,7 @@ bool DNP3::start()
 		std::shared_ptr<IChannel> channel =
 			manager->AddTCPClient(m_serviceName + "_" + remoteLabel, // alias in log messages
 				      logLevels, // filter what gets logged
-				      auto, // how connections will be retried
+				      retry, // how connections will be retried
 				      // host names or IP address of remote endpoint
 				      outstation->address, 
 				      // interface adapter on which to attempt the connection (any adapter)


### PR DESCRIPTION
 Connection retry timings are not set to min 20 seconds and 5 minutes maximum

The dnp3 library uses an algo that reduces the rate or connection retry.

Logged error messages will change accordingly.

Prevous set, Default() was 1 second and 1 minute